### PR TITLE
chore: Update Go version to 1.23.3 and Busybox to 1.37.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23.3-bookworm as builder
+FROM golang:1.22.9-bookworm as builder
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-bookworm as builder
+FROM golang:1.23.3-bookworm as builder
 
 WORKDIR /app
 
@@ -12,7 +12,7 @@ COPY cmd /app/cmd
 ARG COMMIT_SHA
 RUN make
 
-FROM busybox
+FROM busybox:1.37.0
 
 COPY --from=builder /app/remote /usr/local/bin/remote
 RUN chmod +x /usr/local/bin/remote


### PR DESCRIPTION
Signed-off-by: Javier Lopez <javier@okteto.com>

Update Go version to latest one to remove CVEs and update busybox to use a fixed version