### PR TITLE
update golang to 1.24.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.11-bookworm AS builder
+FROM golang:1.24.12-bookworm AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/okteto/remote
 
-go 1.24.11
+go 1.24.12
 
 require (
 	github.com/creack/pty v1.1.11


### PR DESCRIPTION
## Summary
- Updated golang from 1.24.11 to 1.24.12 in Dockerfile
- Updated go version in go.mod to 1.24.12
- Trivy scan confirms 0 vulnerabilities in the built image

## Test plan
- [x] Built Docker image successfully
- [x] Scanned with trivy - 0 HIGH/CRITICAL vulnerabilities found

🤖 Generated with [Claude Code](https://claude.com/claude-code)